### PR TITLE
Adapt javaccssl code to new debugger plugins

### DIFF
--- a/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/META-INF/MANIFEST.MF
@@ -44,7 +44,9 @@ Require-Bundle: org.eclipse.ui,
  org.gemoc.executionframework.engine.ui;bundle-version="0.1.0",
  org.gemoc.executionframework.extensions.sirius,
  org.gemoc.xdsmlframework.ui.utils,
- org.eclipse.jface
+ org.eclipse.jface,
+ org.gemoc.executionframework.debugger,
+ org.gemoc.executionframework.debugger.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.gemoc.execution.concurrent.ccsljavaengine.ui,

--- a/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/commands/GemocToggleBreakpointHandler.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/commands/GemocToggleBreakpointHandler.java
@@ -14,7 +14,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.gemoc.execution.concurrent.ccsljavaengine.ui.launcher.Launcher;
 import org.gemoc.execution.concurrent.ccsljavaengine.ui.views.stimulimanager.ModelSpecificEventWrapper;
-import org.gemoc.executionframework.engine.ui.debug.breakpoint.GemocBreakpoint;
+import org.gemoc.executionframework.debugger.GemocBreakpoint;
 
 import fr.inria.aoste.timesquare.ecl.feedback.feedback.ModelSpecificEvent;
 import fr.inria.diverse.trace.commons.model.trace.MSEOccurrence;

--- a/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/debug/GemocModelDebugger.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/debug/GemocModelDebugger.java
@@ -6,10 +6,10 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcorePackage;
+import org.gemoc.executionframework.debugger.AbstractGemocDebugger;
+import org.gemoc.executionframework.debugger.GemocBreakpoint;
 import org.gemoc.executionframework.engine.core.AbstractExecutionEngine;
 import org.gemoc.executionframework.engine.core.EngineStoppedException;
-import org.gemoc.executionframework.engine.ui.debug.AbstractGemocDebugger;
-import org.gemoc.executionframework.engine.ui.debug.breakpoint.GemocBreakpoint;
 import org.gemoc.executionframework.ui.utils.ViewUtils;
 import org.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;

--- a/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/debug/sirius/action/GemocConcurrentToggleBreakpointAction.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/debug/sirius/action/GemocConcurrentToggleBreakpointAction.java
@@ -1,7 +1,7 @@
 package org.gemoc.execution.concurrent.ccsljavaengine.ui.debug.sirius.action;
 
 import org.gemoc.execution.concurrent.ccsljavaengine.ui.Activator;
-import org.gemoc.executionframework.engine.ui.debug.sirius.action.GemocToggleBreakpointAction;
+import org.gemoc.executionframework.debugger.ui.breakpoints.GemocToggleBreakpointAction;
 
 /**
  * commons class for all Gemoc based models

--- a/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/Launcher.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/Launcher.java
@@ -34,11 +34,10 @@ import org.gemoc.execution.concurrent.ccsljavaengine.ui.views.step.LogicalStepsV
 import org.gemoc.execution.concurrent.ccsljavaengine.ui.views.stimulimanager.StimuliManagerView;
 import org.gemoc.execution.concurrent.ccsljavaxdsml.api.core.IConcurrentExecutionEngine;
 import org.gemoc.execution.concurrent.ccsljavaxdsml.api.moc.ISolver;
-import org.gemoc.executionframework.engine.commons.EngineContextException;
+import org.gemoc.executionframework.debugger.AbstractGemocDebugger;
+import org.gemoc.executionframework.debugger.AnnotationMutableFieldExtractor;
+import org.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.gemoc.executionframework.engine.ui.commons.RunConfiguration;
-import org.gemoc.executionframework.engine.ui.debug.AbstractGemocDebugger;
-import org.gemoc.executionframework.engine.ui.debug.AnnotationMutableFieldExtractor;
-import org.gemoc.executionframework.engine.ui.debug.IMutableFieldExtractor;
 import org.gemoc.executionframework.engine.ui.launcher.AbstractGemocLauncher;
 import org.gemoc.executionframework.extensions.sirius.services.AbstractGemocAnimatorServices;
 import org.gemoc.executionframework.extensions.sirius.services.AbstractGemocDebuggerServices;


### PR DESCRIPTION
Makes minor changes to concurrency code to match changes proposed in t his PR: https://github.com/SiriusLab/ModelDebugging/pull/19