### PR TITLE
Fix possible wrong generation of String import in the builder

### DIFF
--- a/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/GemocLanguageDesignerBuilder.java
+++ b/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/GemocLanguageDesignerBuilder.java
@@ -338,7 +338,8 @@ public class GemocLanguageDesignerBuilder extends IncrementalProjectBuilder {
 					char[][] typeNamesType= new char[][] { simpleNameType.toCharArray() };
 					IType fieldType = findAnyTypeInWorkspace(qualificationsType, typeNamesType);
 					if(fieldType != null) {
-						if(fieldType.getElementName().compareTo("Object") != 0) {
+						String fieldName = fieldType.getElementName();
+						if(!fieldName.equals("Object") && !fieldName.equals("String")) {
 							sbExtraImport.append("import "+fieldType.getFullyQualifiedName()+";\n");
 						}
 						sbContent.append("  public static "+simpleNameType +" get"+f.getElementName()+"(EObject eObject) {\n" + 


### PR DESCRIPTION
On my system using openjdk, an import to `com.sun.org.apache.xpath.internal.operations.String` was generated by the `GemocLanguageDesignerBuilder`, which resulted in uncompilable generated code. This commit simply checks whether the type to import is String, and does not generate an import in such a case.