### PR TITLE
Exhaustive concurrent simulation engine

### DIFF
--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/timesquare/moc/impl/CcslSolver.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/timesquare/moc/impl/CcslSolver.java
@@ -337,6 +337,7 @@ public class CcslSolver implements org.eclipse.gemoc.execution.concurrent.ccslja
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
 		}
+		solverWrapper.getSolver().clearStepData();
 	}
 	
 	@Override
@@ -563,13 +564,13 @@ public class CcslSolver implements org.eclipse.gemoc.execution.concurrent.ccslja
 		try {
 			if (((RelationModelListener) relationModelGenerator.irml).lrelation.size() == 0){
 				relationModelGenerator.addClockConstraint(step);
-				System.out.println("initialization of the occurrence relation model: done");
+//				System.out.println("initialization of the occurrence relation model: done");
 			}
 				relationModelGenerator.resolve(step);
 				lastOccurrenceRelations.addAll(relationModelGenerator.getLastOccurrenceRelations());
 		} catch (Throwable e) {
 
-			System.err.println("****************\nErreur Relation Model\n*****************\n");
+//			System.err.println("****************\nErreur Relation Model\n*****************\n");
 			throw e;
 		}
 		

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/Launcher.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/Launcher.java
@@ -34,6 +34,7 @@ import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
 import org.eclipse.gemoc.dsl.debug.ide.adapter.IDSLCurrentInstructionListener;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.commons.ConcurrentModelExecutionContext;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.commons.ConcurrentRunConfiguration;
+import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dsa.executors.explorer.ExhaustiveConcurrentExecutionEngine;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse.ConcurrentExecutionEngine;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.Activator;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.views.step.LogicalStepsView;
@@ -107,8 +108,11 @@ public class Launcher extends AbstractGemocLauncher<IConcurrentExecutionContext>
 						"Cannot instanciate solver from language definition", e));
 			}
 
-			_executionEngine = new ConcurrentExecutionEngine(concurrentexecutionContext, _solver);
-
+			if (runConfiguration.getIsExhaustiveSimulation()) {
+				_executionEngine = new ExhaustiveConcurrentExecutionEngine(concurrentexecutionContext, _solver);
+			}else {
+				_executionEngine = new ConcurrentExecutionEngine(concurrentexecutionContext, _solver);
+			}
 			openViewsRecommandedByAddons(runConfiguration);
 
 			// And we start it within a dedicated job

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/tabs/LaunchConfigurationAdvancedTab.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/tabs/LaunchConfigurationAdvancedTab.java
@@ -66,7 +66,8 @@ public class LaunchConfigurationAdvancedTab extends LaunchConfigurationTab {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				setDirty(true);
-				notifyAll();
+				updateLaunchConfigurationDialog();
+				getLaunchConfigurationDialog().updateButtons();
 			}
 			
 			@Override

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/tabs/LaunchConfigurationAdvancedTab.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/launcher/tabs/LaunchConfigurationAdvancedTab.java
@@ -25,10 +25,12 @@ import org.eclipse.gemoc.executionframework.engine.core.RunConfiguration;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -41,6 +43,7 @@ public class LaunchConfigurationAdvancedTab extends LaunchConfigurationTab {
 
 	protected Composite _parent;
 	protected Text _timemodelLocationText;
+	protected Button _isExhaustive;
 	public int GRID_DEFAULT_WIDTH = 200;
 
 	@Override
@@ -56,6 +59,22 @@ public class LaunchConfigurationAdvancedTab extends LaunchConfigurationTab {
 		Group executionModelArea = createGroup(area, "execution model (.timemodel):");
 		createModelLayout(executionModelArea , null);
 	
+		_isExhaustive =createCheckButton(area, "Do Exhaustive Simulation");
+		
+		_isExhaustive.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				setDirty(true);
+				notifyAll();
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				setDirty(true);
+				notifyAll();
+			}
+		});
 
 	}
 
@@ -71,6 +90,7 @@ public class LaunchConfigurationAdvancedTab extends LaunchConfigurationTab {
 		try {
 			ConcurrentRunConfiguration runConfiguration = new ConcurrentRunConfiguration(configuration);
 			_timemodelLocationText.setText(runConfiguration.getExecutionModelPath());
+			_isExhaustive.setSelection(runConfiguration.getIsExhaustiveSimulation());
 		} catch (CoreException e) {
 			Activator.error(e.getMessage(), e);
 		}
@@ -79,6 +99,7 @@ public class LaunchConfigurationAdvancedTab extends LaunchConfigurationTab {
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		configuration.setAttribute(ConcurrentRunConfiguration.EXTRA_TIMEMODEL_PATH, _timemodelLocationText.getText());
+		configuration.setAttribute(ConcurrentRunConfiguration.EXHAUSTIVE_MODE, _isExhaustive.getSelection());
 	}
 
 	@Override

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/commons/ConcurrentRunConfiguration.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/commons/ConcurrentRunConfiguration.java
@@ -24,6 +24,7 @@ public class ConcurrentRunConfiguration extends RunConfiguration implements ICon
 	public static final String DECIDER_SOLVER = "Solver decider";
 	public static final String DECIDER_ASKUSER_STEP_BY_STEP = "Step by step user decider";
 	public static final String EXTRA_TIMEMODEL_PATH = "TIMEMODEL_PATH";
+	public static final String EXHAUSTIVE_MODE = "Do Exhaustive Simulation";
 	
 	private String _modelInitializationMethod;
 	private String _modelInitializationArguments;
@@ -39,12 +40,14 @@ public class ConcurrentRunConfiguration extends RunConfiguration implements ICon
 		
 		_deciderName = getAttribute(LAUNCH_SELECTED_DECIDER, "");
 		_executionModelPath = getAttribute(EXTRA_TIMEMODEL_PATH, "");
+		_isExhaustive = getAttribute(EXHAUSTIVE_MODE, false);
 		_modelInitializationMethod = getAttribute(LAUNCH_INITIALIZATION_METHOD, "");
 		_modelInitializationArguments = getAttribute(LAUNCH_INITIALIZATION_ARGUMENTS, "");
 	}
 	
 	protected String _deciderName;
 	protected String _executionModelPath;
+	protected boolean _isExhaustive;
 	
 	@Override
 	public String getDeciderName() {
@@ -54,6 +57,11 @@ public class ConcurrentRunConfiguration extends RunConfiguration implements ICon
 	@Override
 	public String getExecutionModelPath() {
 		return _executionModelPath;
+	}
+	
+	@Override
+	public boolean getIsExhaustiveSimulation() {
+		return _isExhaustive;
 	}
 
 	@Override

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/ControlAndRTDState.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/ControlAndRTDState.java
@@ -1,0 +1,105 @@
+package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dsa.executors.explorer;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate.k3ModelState.ElementState;
+import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate.k3ModelState.K3ModelState;
+import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate.k3ModelState.K3ModelStateFactory;
+
+public class ControlAndRTDState implements Serializable {
+	
+	private static final long serialVersionUID = 0;
+	public K3ModelState modelState = K3ModelStateFactory.eINSTANCE.createK3ModelState();
+	public byte[] moCCState = null;
+	
+	public ControlAndRTDState(K3ModelState modelS, byte[] moccS) {
+		super();
+		modelState = modelS;
+		moCCState = moccS;
+	}
+	
+	@Override
+	public boolean equals(Object state){
+		return this.equals((ControlAndRTDState)state);
+	}
+
+	public boolean equals(ControlAndRTDState state){
+//		System.out.println("################################################################################################\ncompare "+this+ "with "+state);
+		if (! Arrays.equals(state.moCCState, this.moCCState)) {
+			return false;
+		}
+		int i = 0;
+		for(ElementState newStateElemState : state.modelState.getOwnedElementstates()) {
+			boolean found = false;
+			for (ElementState modelElementState : this.modelState.getOwnedElementstates()) {
+				if(areEquals(modelElementState,newStateElemState)) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	private boolean areEquals(ElementState modelElementState, ElementState newStateElemState) {
+		for(Object newStateRTD :  newStateElemState.getSavedRTDs()) {
+			boolean RTDfound = false;
+			for(Object modelRTD :  modelElementState.getSavedRTDs()) {
+				if (newStateRTD.equals(modelRTD)) {
+					RTDfound = true;
+					break;
+				}
+			}
+			if (!RTDfound) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static Integer index = 0;
+	@Override
+	public String toString() {
+		StringBuilder sbRes = new StringBuilder();//(index++).toString());
+		for(ElementState elemState : this.modelState.getOwnedElementstates()) {
+			try {
+				EList<EAttribute> eAllAttributes = elemState.getModelElement().eClass().getEAllAttributes();
+				for (EAttribute attr : eAllAttributes) {
+					if ("name".equals(attr.getName())) {
+						final Object value = elemState.getModelElement().eGet(attr, false);
+						if (value instanceof String) {
+							sbRes.append(((String) value)+"\n");
+							break;
+						}
+					}
+				}
+			} catch (IllegalArgumentException | SecurityException e1) {
+				sbRes.append(elemState.getModelElement().getClass().getName()+index);
+				index++;
+			}
+//			sbRes.append(elemState.getModelElement());
+			for(Object rtd : elemState.getSavedRTDs()) {
+				//the Object is an AttributeNameToValue...
+				try {
+					Field f = rtd.getClass().getDeclaredField("name");
+					f.setAccessible(true);
+					sbRes.append("\t"+f.get(rtd)+":");
+					f = rtd.getClass().getDeclaredField("value");
+					f.setAccessible(true);
+					sbRes.append("\t"+f.get(rtd)+"\n");
+				} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		return sbRes.toString();
+	}
+	
+}

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/ExhaustiveConcurrentExecutionEngine.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/ExhaustiveConcurrentExecutionEngine.java
@@ -11,93 +11,31 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dsa.executors.explorer;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
 
-import org.eclipse.core.internal.resources.Workspace;
-import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.transaction.RecordingCommand;
-import org.eclipse.emf.transaction.TransactionalEditingDomain;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.concurrentmse.FeedbackMSE;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse.ASynchroneExecution;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse.ConcurrentExecutionEngine;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse.OperationExecution;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse.SynchroneExecution;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.dsa.helper.IK3ModelStateHelper;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core.IConcurrentExecutionContext;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core.IFutureAction;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core.ILogicalStepDecider;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.dsa.executors.CodeExecutionException;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.dsa.executors.ICodeExecutor;
-import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.dse.IMSEStateController;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.moc.ISolver;
-import org.eclipse.gemoc.executionframework.engine.Activator;
-import org.eclipse.gemoc.executionframework.engine.core.CommandExecution;
-import org.eclipse.gemoc.executionframework.engine.core.EngineStoppedException;
-import org.eclipse.gemoc.moccml.mapping.feedback.feedback.ActionModel;
-import org.eclipse.gemoc.moccml.mapping.feedback.feedback.When;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericParallelStep;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericStep;
-import org.eclipse.gemoc.trace.commons.model.trace.MSE;
-import org.eclipse.gemoc.trace.commons.model.trace.ParallelStep;
 import org.eclipse.gemoc.trace.commons.model.trace.SmallStep;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
-import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext;
-import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 
-import fr.inria.diverse.k3.al.annotationprocessor.InitializeModel;
 import grph.Grph;
 
 /**
- * Basic abstract implementation of the ExecutionEngine, independent from the technologies used for the solver, the
- * executor and the feedback protocol. It can display the runtime execution information to its registered observers.
+ * Experimental feature to explore the whole state space of a model. Seen for now as an execution engine but may before a dedicated tool that delegate actual execution to a gemoc engine.
  * 
- * There are two phases of initializations for this entity:
- * <ul>
- * <li>the constructor sets the language-specific elements such as DomainSpecificEvents, Solver, EventExecutor,
- * FeedbackPolicy</li>
- * <li>the initialize method sets the model-specific elements such as Model and ModelLoader.</li>
- * </ul>
- * From the Model, we can derive :
- * <ul>
- * <li>the Model of Execution (using the DomainSpecificEvents)</li>
- * <li>the Higher-order-transformation (TODO)) and the Solver Input (using the Model of Execution and the Solver Input
- * Builder provided by the Solver).</li>
- * </ul>
+ * @see ConcurrentExecutionEngine
  * 
- * There are a few elements that could enter the ExecutionEngine, maybe after being reified as their own data
- * structures:
- * <ul>
- * <li>{@link #scheduledSteps} is the FIFO of LogicalSteps. We use a FIFO because sometimes we may want to memorize
- * steps in order to go back in the past and replay given steps. When the engine seeks to reach the next step of
- * execution, it will first check if there is something in this FIFO. If there is not, then a new step is requested from
- * the solver.</li>
- * <li>{@link #schedulingTrace} is a map recording the order in which the steps of the solver have been used.</li>
- * <li>{@link #scheduledEventsMap} records which step is linked to which list of MSEs. It is to be noticed that not all
- * the MSEs were executed. Indeed, some may have been illegal at the time (with regards to the MoC) and thus discarded
- * during the execution of this step.</li>
- * <li>{@link #executionTrace} records the steps and the actual MSEs that were actually executed.</li>
- * </ul>
- * 
- * @see IExecutionEngine
- * 
- * @author flatombe
- * @author didier.vojtisek@inria.fr
  * @author julien.deantoni@polytech.unice.fr
  * @param <T>
  * 
@@ -107,16 +45,6 @@ public class ExhaustiveConcurrentExecutionEngine extends ConcurrentExecutionEngi
 	public ExhaustiveConcurrentExecutionEngine(IConcurrentExecutionContext concurrentexecutionContext, ISolver s) throws CoreException 
 	{
 		super(concurrentexecutionContext,s);
-	}
-
-	@Override
-	public ILogicalStepDecider getLogicalStepDecider() {
-		return _logicalStepDecider;
-	}
-
-	@Override
-	public void changeLogicalStepDecider(ILogicalStepDecider newDecider) {
-		_logicalStepDecider = newDecider;
 	}
 
 	
@@ -208,10 +136,6 @@ public class ExhaustiveConcurrentExecutionEngine extends ConcurrentExecutionEngi
 		ps.close();
 	}
 
-	
-	private void restoreComputedPossibleLogicalSteps() {
-		getSolver().computeAndGetPossibleLogicalSteps();
-	}
 
 	private String prettyPrint(GenericParallelStep aStep) {
 		StringBuilder sbStep = new StringBuilder();
@@ -222,322 +146,11 @@ public class ExhaustiveConcurrentExecutionEngine extends ConcurrentExecutionEngi
 	}
 		
 
-//	private Step<?> selectAndExecuteLogicalStep() throws InterruptedException {
-//		setEngineStatus(EngineStatus.RunStatus.WaitingLogicalStepSelection);
-//		notifyAboutToSelectLogicalStep();
-//		Step<?> selectedLogicalStep = getLogicalStepDecider().decide(this, getPossibleLogicalSteps());
-//		if (selectedLogicalStep != null) {
-//			setSelectedLogicalStep(selectedLogicalStep);
-//			setEngineStatus(EngineStatus.RunStatus.Running);
-//			notifyLogicalStepSelected();
-//			// run all the event occurrences of this logical
-//			// step
-//			executeSelectedLogicalStep();
-//		}
-//		return selectedLogicalStep;
-//	}
-
-	/**
-	 * run all the event occurrences of this logical step
-	 * 
-	 * @param logicalStepToApply
-	 */
-	@SuppressWarnings("unchecked")
-	public void executeSelectedLogicalStep() {
-		// = step in debug mode, goes to next logical step
-		// -> run all event occurrences of the logical step
-		// step into / open internal thread and pause them
-		// each concurrent event occurrence is presented as a separate
-		// thread in the debugger
-		// execution feedback is sent to the solver so it can take internal
-		// event into account
-
-		if (!_isStopped) { // execute while stopped may occur when we push the
-							// stop button when paused in the debugger
-			beforeExecutionStep(_selectedLogicalStep);
-			for (final Step<?> step : ((ParallelStep<Step<?>,?>) _selectedLogicalStep).getSubSteps()) {
-				SmallStep<?> sstep = (SmallStep<?>) step;
-				executeAssociatedActions(sstep.getMseoccurrence().getMse());
-				executeSmallStep(sstep);
-			}
-			afterExecutionStep();
-		}
-	}
-
-	private void executeAssociatedActions(MSE mse) {
-		synchronized (_futureActionsLock) {
-			ArrayList<IFutureAction> actionsToRemove = new ArrayList<IFutureAction>();
-			for (IFutureAction action : _futureActions) {
-				if (action.getTriggeringMSE() == mse) {
-					actionsToRemove.add(action);
-					action.perform();
-				}
-			}
-			_futureActions.removeAll(actionsToRemove);
-		}
-	}
-
-	private void executeSmallStep(SmallStep<?> smallStep) {
-		MSE mse = smallStep.getMseoccurrence().getMse();
-		if (mse.getAction() != null) {
-			ArrayList<When> whenStatements = new ArrayList<When>();
-			// we are in a concurrent engine, the MSE should be a FeedbackMSE
-			if (mse instanceof FeedbackMSE) {
-				ActionModel feedbackModel = ((IConcurrentExecutionContext) _executionContext).getFeedbackModel();
-				for (When w : feedbackModel.getWhenStatements()) {
-					if (w.getSource() == ((FeedbackMSE) mse).getFeedbackModelSpecificEvent()) {
-						whenStatements.add(w);
-					}
-				}
-			}
-			OperationExecution execution = null;
-			Consumer<Step<?>> beforeStep = s -> {
-				beforeExecutionStep(s);
-			};
-			Runnable afterStep = () -> {
-				afterExecutionStep();
-			};
-			if (whenStatements.size() == 0) {
-				execution = new SynchroneExecution(smallStep, this, beforeStep, afterStep);
-			}
-			// if there is a future, execute async.
-			else {
-				execution = new ASynchroneExecution(smallStep, whenStatements, _mseStateController, this, beforeStep,
-						afterStep);
-			}
-			execution.run();
-		}
-	}
-
 	
-
-	public void updatePossibleLogicalSteps() {
-		for (IMSEStateController c : getConcurrentExecutionContext().getExecutionPlatform()
-				.getMSEStateControllers()) {
-			c.applyMSEFutureStates(getSolver());
-		}
-		synchronized (this) {
-			_possibleLogicalSteps = getSolver().updatePossibleLogicalSteps();
-		}
-	}
-
-	@Override
-	public void recomputePossibleLogicalSteps() {
-		getSolver().revertForceClockEffect();
-		updatePossibleLogicalSteps();
-		notifyProposedLogicalStepsChanged();
-	}
-	@Override
-	public List<Step<?>> getPossibleLogicalSteps() {
-		synchronized (this) {
-			return new ArrayList<Step<?>>(_possibleLogicalSteps);
-		}
-	}
-
-
-	public void notifyLogicalStepSelected() {
-		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
-			try {
-				addon.stepSelected(this, getSelectedLogicalStep());
-			} catch (Exception e) {
-				Activator.getDefault().error("Exception in Addon " + addon + ", " + e.getMessage(), e);
-			}
-		}
-	}
-
-	public void notifyAboutToSelectLogicalStep() {
-		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
-			try {
-				addon.aboutToSelectStep(this, getPossibleLogicalSteps());
-			} catch (Exception e) {
-				Activator.getDefault().error("Exception in Addon " + addon + ", " + e.getMessage(), e);
-			}
-		}
-	}
-
-
-	@Override
-	public Step<?> getSelectedLogicalStep() {
-		synchronized (this) {
-			return _selectedLogicalStep;
-		}
-	}
-
-	@Override
-	public void setSelectedLogicalStep(Step<?> ls) {
-		synchronized (this) {
-			_selectedLogicalStep = ls;
-		}
-	}
-
-	/**
-	 * 
-	 * @return the IConcurrenExecutionContext or null if no such context is available
-	 */
-	@Override
-	public IConcurrentExecutionContext getConcurrentExecutionContext() {
-
-		IExecutionContext<?,?,?> context = getExecutionContext();
-		if (context instanceof IConcurrentExecutionContext) {
-			return (IConcurrentExecutionContext) context;
-		} else
-			return null;
-	}
-
-
-	@Override
-	public ISolver getSolver() {
-		return _solver;
-	}
-
-	public void notifyProposedLogicalStepsChanged() {
-		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
-			try {
-				addon.proposedStepsChanged(this, getPossibleLogicalSteps());
-			} catch (Exception e) {
-				Activator.getDefault().error("Exception in Addon " + addon + ", " + e.getMessage(), e);
-			}
-		}
-	}
-
-	@Override
-	public String toString() {
-		return this.getClass().getName() + "@[Executor=" + getCodeExecutor() + " ; Solver=" + getSolver()
-				+ " ; ModelResource=" + _executionContext.getResourceModel() + "]";
-	}
-
-	@Override
-	public void addFutureAction(IFutureAction action) {
-		synchronized (_futureActionsLock) {
-			_futureActions.add(action);
-		}
-	}
-
-	@Override
-	protected void performStart() {
-		engineStatus.setNbLogicalStepRun(0);
-		try {
-			while (!_isStopped) {
-				performExecutionStep();
-			}
-		} catch (EngineStoppedException ese) {
-			throw ese; // forward the stop exception
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@Override
-	public void setSolver(ISolver solver) {
-		_solver = solver;
-
-	}
-
-	@Override
-	public ICodeExecutor getCodeExecutor() {
-		return getConcurrentExecutionContext().getExecutionPlatform().getCodeExecutor();
-	}
-
-	
-
-
-
-	protected void executeInitializeModelMethod(IConcurrentExecutionContext executionContext) {
-
-		String modelInitializationMethodQName = executionContext.getRunConfiguration().getModelInitializationMethod();
-		if (!modelInitializationMethodQName.isEmpty()) {
-			Object target = executionContext.getResourceModel().getContents().get(0);
-			String modelInitializationMethodName = modelInitializationMethodQName
-					.substring(modelInitializationMethodQName.lastIndexOf(".") + 1);
-			Activator.getDefault()
-					.debug("*** Calling Model initialization method " + modelInitializationMethodName + "(). ***");
-			
-
-			final ArrayList<Object> modelInitializationParameters = new ArrayList<>();
-			ICodeExecutor codeExecutor = getConcurrentExecutionContext().getExecutionPlatform().getCodeExecutor(); 
-			ArrayList<Object> parameters = new ArrayList<Object>();
-			// try with String[] args			
-			parameters.add(new String[1]);
-			List<Method> methods = codeExecutor.findCompatibleMethodsWithAnnotation(target, parameters, InitializeModel.class);
-			if(!methods.isEmpty()){
-				modelInitializationParameters.add(executionContext.getRunConfiguration().getModelInitializationArguments().split("\\r?\\n"));
-			} else {
-				// try with List<String>
-				parameters.clear();
-				parameters.add(new ArrayList<String>());
-				methods.addAll(codeExecutor.findCompatibleMethodsWithAnnotation(target, parameters, InitializeModel.class));
-				if(!methods.isEmpty()){
-					ArrayList<String> modelInitializationArgs = new ArrayList<>();
-					for (String s : executionContext.getRunConfiguration().getModelInitializationArguments().split("\\r?\\n")) {
-						modelInitializationArgs.add(s);
-					}
-					modelInitializationParameters.add(modelInitializationArgs);
-				} else {
-					// try with EList<String>
-					parameters.clear();
-					parameters.add(new BasicEList<String>());
-					methods.addAll(codeExecutor.findCompatibleMethodsWithAnnotation(target, parameters, InitializeModel.class));
-					if(!methods.isEmpty()){
-						BasicEList<String> modelInitializationArgs = new BasicEList<>();
-						for (String s : executionContext.getRunConfiguration().getModelInitializationArguments().split("\\r?\\n")) {
-							modelInitializationArgs.add(s);
-						}
-						modelInitializationParameters.add(modelInitializationArgs);
-					}	
-				}
-			}
-			final TransactionalEditingDomain editingDomain = TransactionalEditingDomain.Factory.INSTANCE
-					.getEditingDomain(getExecutionContext().getResourceModel().getResourceSet());
-			if (editingDomain != null) {
-				final RecordingCommand command = new RecordingCommand(editingDomain,
-						"execute  " + modelInitializationMethodQName) {
-					private List<Object> result = new ArrayList<Object>();
-
-					@Override
-					protected void doExecute() {
-						try {
-							result.add(codeExecutor.execute(target, modelInitializationMethodName, modelInitializationParameters));
-							Activator.getDefault().debug("*** Model initialization done. ***");
-						} catch (CodeExecutionException e) {
-							Activator.getDefault().error("Exception while initializing model " + e.getMessage(), e);
-						}
-					}
-
-					@Override
-					public Collection<?> getResult() {
-						return result;
-					}
-				};
-				CommandExecution.execute(editingDomain, command);
-			} else {
-				try {
-					codeExecutor.execute(target,
-							modelInitializationMethodName, modelInitializationParameters);
-					Activator.getDefault().debug("*** Model initialization done. ***");
-				} catch (CodeExecutionException e) {
-					Activator.getDefault().error("Exception while initializing model " + e.getMessage(), e);
-				}
-			}
-		} else {
-			Activator.getDefault().debug(
-					"*** Model initialization done. (no modelInitialization method defined for the language) ***");
-		}
-
-	}
-
 	@Override
 	public String engineKindName() {
-		return "GEMOC Concurrent Engine";
+		return "GEMOC Exhaustive Concurrent Engine";
 	}
-
-	@Override
-	protected void beforeStart() {
-		// TODO Auto-generated method stub
-		
-	}
-
-
-
 
 
 }

--- a/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/StateSpace.java
+++ b/ccsljava_execution/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dsa/executors/explorer/StateSpace.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017 I3S laboratory, INRIA and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     I3S laboratory and INRIA Kairos - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dsa.executors.explorer;
+
+import grph.Grph;
+import grph.oo.ObjectGrph;
+
+public class StateSpace extends ObjectGrph<ControlAndRTDState, StringBuffer> {
+	
+	public Grph getGrph(){
+		return this.backingGrph;
+	}
+	
+	public ControlAndRTDState initialState = null;
+
+	public int v2i(ControlAndRTDState v) {
+		return super.v2i(v);
+	}
+	
+}

--- a/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/api/core/IConcurrentRunConfiguration.java
+++ b/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/api/core/IConcurrentRunConfiguration.java
@@ -22,4 +22,5 @@ public interface IConcurrentRunConfiguration extends IRunConfiguration{
 	String getExecutionModelPath();
 	String getModelInitializationMethod();
 	String getModelInitializationArguments();
+	boolean getIsExhaustiveSimulation();
 }

--- a/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_execution/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
@@ -45,7 +45,8 @@ Require-Bundle: org.eclipse.ui,
  fr.inria.diverse.melange.ui.templates,
  org.eclipse.gemoc.dsl;bundle-version="3.0.0",
  org.eclipse.jdt;bundle-version="3.13.4",
- org.eclipse.jdt.core.manipulation;bundle-version="1.10.0"
+ org.eclipse.jdt.core.manipulation;bundle-version="1.10.0",
+ org.eclipse.jdt.launching;bundle-version="3.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.filesystem


### PR DESCRIPTION
The goal of this branch is to provide an experimental support for
exhaustive simulation.

It relies on the RTD accessor generated in builder from commit
#77d2afb12fc60b2c7c7869f8297f7db2429beec8 from October 9.

It is actually an extension of the ConcurrentEngine that is called when
the "Do Exhaustive Simulation" check button from the advanced tab is
checked.

It results in a dot file where State label contains a crude
representation of the model state and the transition a representation of
the events (MSE) that occurred from two states.

It will eventually be modified to use a better trace format but can
already be used for some demo. This is a join effort with the recent
enabling of ccsl model checking with CADP.

This PR contains:
 * small changes in the CCSLSolver to ease the reset of solver data
 * extension of the Launcher to take into account the "Do Exhaustive
Simulation" button
 * a set of classes to store the state of both the MoCC and the RTD
 * a new execution engine that runs until no new states have to be
visited (if the state space if finite, and run infinitely otherwise)